### PR TITLE
Release/v0.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ pip-delete-this-directory.txt
 *.log
 
 # Tentative
+ref/*
 exec-test/*
 REQUIREMENT.md
 CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # mcp-bigquery-dryrun
 
-Minimal MCP server for BigQuery SQL validation and dry-run analysis. This server provides exactly two tools for validating and analyzing BigQuery SQL queries without executing them.
+[![PyPI](https://img.shields.io/pypi/v/mcp-bigquery-dryrun.svg)](https://pypi.org/project/mcp-bigquery-dryrun/)
+![PyPI - Downloads](https://img.shields.io/pypi/dd/mcp-bigquery-dryrun)
+
+The `mcp-bugquery-dryrun` package provides a minimal MCP server for BigQuery SQL validation and dry-run analysis. This server provides exactly two tools for validating and analyzing BigQuery SQL queries without executing them.
 
 ** IMPORTANT: This server does NOT execute queries. All operations are dry-run only. Cost estimates are approximations based on bytes processed.**
 
@@ -15,7 +18,7 @@ Minimal MCP server for BigQuery SQL validation and dry-run analysis. This server
 
 ### Prerequisites
 
-- Python 3.9+
+- Python 3.10+
 - Google Cloud SDK with BigQuery API enabled
 - Application Default Credentials configured
 
@@ -108,7 +111,7 @@ Or if installed from source:
 
 ## Tools
 
-### bq.validate_sql
+### bq_validate_sql
 
 Validate BigQuery SQL syntax without executing the query.
 
@@ -143,7 +146,7 @@ Validate BigQuery SQL syntax without executing the query.
 }
 ```
 
-### bq.dry_run_sql
+### bq_dry_run_sql
 
 Perform a dry-run to get cost estimates and metadata without executing the query.
 
@@ -199,7 +202,7 @@ Perform a dry-run to get cost estimates and metadata without executing the query
 ### Validate a Simple Query
 
 ```python
-# Tool: bq.validate_sql
+# Tool: bq_validate_sql
 {
   "sql": "SELECT 1"
 }
@@ -209,7 +212,7 @@ Perform a dry-run to get cost estimates and metadata without executing the query
 ### Validate with Parameters
 
 ```python
-# Tool: bq.validate_sql
+# Tool: bq_validate_sql
 {
   "sql": "SELECT * FROM users WHERE name = @name AND age > @age",
   "params": {
@@ -222,7 +225,7 @@ Perform a dry-run to get cost estimates and metadata without executing the query
 ### Get Cost Estimate
 
 ```python
-# Tool: bq.dry_run_sql
+# Tool: bq_dry_run_sql
 {
   "sql": "SELECT * FROM `bigquery-public-data.samples.shakespeare`",
   "pricePerTiB": 5.0
@@ -233,7 +236,7 @@ Perform a dry-run to get cost estimates and metadata without executing the query
 ### Analyze Complex Query
 
 ```python
-# Tool: bq.dry_run_sql
+# Tool: bq_dry_run_sql
 {
   "sql": """
     WITH user_stats AS (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,14 +16,13 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Database",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "mcp>=1.0.0",
     "google-cloud-bigquery>=3.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-bigquery-dryrun"
-version = "0.1.0"
+version = "0.2.0-dev"
 description = "Minimal MCP server for BigQuery SQL validation and dry-run analysis"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/src/mcp_bigquery_dryrun/__init__.py
+++ b/src/mcp_bigquery_dryrun/__init__.py
@@ -1,6 +1,6 @@
 """MCP BigQuery Dry-Run Server - Minimal MCP server for BigQuery SQL validation and dry-run analysis."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0-dev"
 __author__ = "caron14"
 __email__ = "caron14@users.noreply.github.com"
 

--- a/src/mcp_bigquery_dryrun/bigquery_client.py
+++ b/src/mcp_bigquery_dryrun/bigquery_client.py
@@ -24,9 +24,11 @@ def get_bigquery_client() -> bigquery.Client:
     location = os.environ.get("BQ_LOCATION")
     
     try:
-        client = bigquery.Client(project=project)
+        # Create client with location if provided
         if location:
-            client.location = location
+            client = bigquery.Client(project=project, location=location)
+        else:
+            client = bigquery.Client(project=project)
         return client
     except DefaultCredentialsError as e:
         raise DefaultCredentialsError(

--- a/src/mcp_bigquery_dryrun/server.py
+++ b/src/mcp_bigquery_dryrun/server.py
@@ -65,7 +65,7 @@ async def handle_list_tools() -> list[types.Tool]:
     """List available MCP tools."""
     return [
         types.Tool(
-            name="bq.validate_sql",
+            name="bq_validate_sql",
             description="Validate BigQuery SQL syntax without executing the query",
             inputSchema={
                 "type": "object",
@@ -84,7 +84,7 @@ async def handle_list_tools() -> list[types.Tool]:
             }
         ),
         types.Tool(
-            name="bq.dry_run_sql",
+            name="bq_dry_run_sql",
             description="Perform a dry-run of a BigQuery SQL query to get cost estimates and metadata",
             inputSchema={
                 "type": "object",
@@ -116,7 +116,7 @@ async def handle_call_tool(
 ) -> list[types.TextContent | types.ImageContent | types.EmbeddedResource]:
     """Handle tool execution requests."""
     
-    if name == "bq.validate_sql":
+    if name == "bq_validate_sql":
         result = await validate_sql(
             sql=arguments["sql"],
             params=arguments.get("params")
@@ -126,7 +126,7 @@ async def handle_call_tool(
             text=json.dumps(result, indent=2)
         )]
     
-    elif name == "bq.dry_run_sql":
+    elif name == "bq_dry_run_sql":
         result = await dry_run_sql(
             sql=arguments["sql"],
             params=arguments.get("params"),

--- a/tests/test_min.py
+++ b/tests/test_min.py
@@ -162,8 +162,8 @@ class TestWithoutCredentials:
         assert len(tools) == 2
         
         tool_names = [tool.name for tool in tools]
-        assert "bq.validate_sql" in tool_names
-        assert "bq.dry_run_sql" in tool_names
+        assert "bq_validate_sql" in tool_names
+        assert "bq_dry_run_sql" in tool_names
         
         # Check tool schemas
         for tool in tools:


### PR DESCRIPTION
This pull request updates the `mcp-bigquery-dryrun` package with several improvements and breaking changes. The most significant updates are the renaming of tool names to use underscores instead of dots, raising the minimum supported Python version to 3.10, and updating the project version to `0.2.0-dev`. Documentation and tests have been updated to reflect these changes, and there are minor improvements to the BigQuery client initialization.


**Python version and packaging updates:**
- Increased the minimum required Python version from 3.9 to 3.10 in `pyproject.toml` and documentation, and removed the Python 3.9 classifier. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L19-R25) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L18-R21)
- Updated the project version to `0.2.0-dev` in `pyproject.toml` and `__init__.py`. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3) [[2]](diffhunk://#diff-2cb1f729d54d159fc70077dd40556e0f0df7e93bdebfea1f588ca534f9ffdd06L3-R3)

**Code improvements:**
- Improved BigQuery client initialization to set the `location` parameter at instantiation time, rather than modifying the client object after creation.